### PR TITLE
make try_command not retry on failure

### DIFF
--- a/lib/rubygsm/core.rb
+++ b/lib/rubygsm/core.rb
@@ -416,7 +416,7 @@ class Modem
 	def try_command(cmd, *args)
 		begin
 			log_incr "Trying Command: #{cmd}"
-			out = command(cmd, *args)
+			out = command!(cmd, *args)
 			log_decr "=#{out.inspect} // try_command"
 			return out
 			


### PR DESCRIPTION
Previously it would keep retrying the command even if executed using try_command, so rubygsm would hang on init if the modem doesn't understand any of the init AT commands.
